### PR TITLE
Enabling A1n as Starting Point for LAD SHMS Optics

### DIFF
--- a/PARAM/SHMS/GEN/pcana.param
+++ b/PARAM/SHMS/GEN/pcana.param
@@ -8,7 +8,9 @@ SHMS_CentralPathLen = 18.1*100   ; 18.1 m (or 1810 cm)
 ;p_recon_coeff_filename = "DATFILES/shms-2011-26cm-monte_q2_m015_rec.dat"
 ;p_recon_coeff_filename = "DATFILES/shms_dipole_2plow.dat"
 ;p_recon_coeff_filename = "DATFILES/shms-2017-optimized.dat"
-p_recon_coeff_filename = "DATFILES/shms-2017-optimized_delta_newfit3.dat"
+;p_recon_coeff_filename = "DATFILES/shms-2017-optimized_delta_newfit3.dat"
+;Added by E.Wertz a reasonable first try. Till LAD optics is optimized.
+p_recon_coeff_filename = "DATFILES/shms_newfit_global_zbin_allA1n.dat"
 
 ; fall 2019 defocused tune -> Q2 current set to 120% of nominal tune
 ; p_recon_coeff_filename = "DATFILES/shms-2017-26cm-monte_quads_p18_q2_120_rec.dat"


### PR DESCRIPTION
Noticed that pcana.param is pointing to an older matrix. We want to use the extended matrix from A1n as the starting place. While optimizing any LAD SHMS optics matrix. Presumably this will change to a LAD specific matrix in future.