### PR TITLE
Reverting to the SHMS 2017 delta3 newfit optics matrix

### DIFF
--- a/PARAM/SHMS/GEN/pcana.param
+++ b/PARAM/SHMS/GEN/pcana.param
@@ -8,9 +8,9 @@ SHMS_CentralPathLen = 18.1*100   ; 18.1 m (or 1810 cm)
 ;p_recon_coeff_filename = "DATFILES/shms-2011-26cm-monte_q2_m015_rec.dat"
 ;p_recon_coeff_filename = "DATFILES/shms_dipole_2plow.dat"
 ;p_recon_coeff_filename = "DATFILES/shms-2017-optimized.dat"
-;p_recon_coeff_filename = "DATFILES/shms-2017-optimized_delta_newfit3.dat"
+p_recon_coeff_filename = "DATFILES/shms-2017-optimized_delta_newfit3.dat"
 ;Added by E.Wertz a reasonable first try. Till LAD optics is optimized.
-p_recon_coeff_filename = "DATFILES/shms_newfit_global_zbin_allA1n.dat"
+;p_recon_coeff_filename = "DATFILES/shms_newfit_global_zbin_allA1n.dat"
 
 ; fall 2019 defocused tune -> Q2 current set to 120% of nominal tune
 ; p_recon_coeff_filename = "DATFILES/shms-2017-26cm-monte_quads_p18_q2_120_rec.dat"


### PR DESCRIPTION
Changing the SHMS optics matrix back to the 2017 delta3 newfit. This version looks more reliable than A1n extended for the LAD data.